### PR TITLE
[#65] 카운트다운 중간에 움직이면 카운트다운 중지 구현, 이전 값이 잘못 넘어오는 부분 해결

### DIFF
--- a/apps/client/src/pages/WebcamPage.tsx
+++ b/apps/client/src/pages/WebcamPage.tsx
@@ -14,7 +14,7 @@ const WebcamPage = () => {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const socketRef = useRef<any>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [isValid, setIsValid] = useState(true);
+  const [isValid, setIsValid] = useState(false);
   const { verificationResult, setVerificationResult } =
     useContext(PhotoContext);
   const [countdown, setCountdown] = useState<number>(3);
@@ -88,6 +88,10 @@ const WebcamPage = () => {
   };
 
   useEffect(() => {
+    if (verificationResult) {
+      setVerificationResult(null);
+    }
+
     socketRef.current = io("http://localhost:5002/socket");
     socketRef.current.on(
       "stream",
@@ -133,6 +137,8 @@ const WebcamPage = () => {
   useEffect(() => {
     if (verificationResult && verificationResult.every((item) => item === 1)) {
       setIsValid(true);
+    } else {
+      setIsValid(false);
     }
   }, [verificationResult]);
 
@@ -151,9 +157,7 @@ const WebcamPage = () => {
         clearInterval(countdownIntervalId);
       };
     }
-  }, [isValid]);
-
-  //const tempVerificationResult = [1, 1, 1, 1, 1];
+  }, [isValid, verificationResult]);
 
   const checklistArr: string[] = [
     "착용물이 없어요",
@@ -167,7 +171,7 @@ const WebcamPage = () => {
     <Container>
       {isLoading ? "loading..." : ""}
       <Modal visible={isValid.valueOf()}>
-        움직이지 말아주세요
+        움직이지 말아주세요. 움직이면 재촬영이 필요합니다.
         <br /> <br /> {countdown > 0 ? countdown : <br />}
       </Modal>
       <CameraContainer id="CameraContainer">


### PR DESCRIPTION
- 서버랑 통신 잘 되는지 확인 완료, 카운트다운 중간 중지
  - flask 등 더 빨리 통신 할 수 있다면 3초 내에 할 수 있음
  - 현재, 서버 부하 방지를 위해 3초에 한번 소통
  - 따라서 카운트다운을 3초가 아닌 5초로 지정
- 이전 값이 잘못 넘어온 부분 해결
  - 상태관리 흐름 다시 짚어보기